### PR TITLE
Improve highlight

### DIFF
--- a/syntaxes/qiq.tmLanguage.json
+++ b/syntaxes/qiq.tmLanguage.json
@@ -22,13 +22,28 @@
 			]
 		},
 		"strings": {
-			"name": "string.quoted.double.qiq",
-			"begin": "\"",
-			"end": "\"",
 			"patterns": [
 				{
-					"name": "constant.character.escape.qiq",
-					"match": "\\\\."
+					"name": "string.quoted.double.qiq",
+					"begin": "\"",
+					"end": "\"",
+					"patterns": [
+						{
+							"name": "constant.character.escape.qiq",
+							"match": "\\\\."
+						}
+					]
+				},
+				{
+					"name": "string.quoted.single.qiq",
+					"begin": "'",
+					"end": "'",
+					"patterns": [
+						{
+							"name": "constant.character.escape.qiq",
+							"match": "\\\\."
+						}
+					]
 				}
 			]
 		},
@@ -52,12 +67,31 @@
 					"name": "keyword.control.qiq"
 				},
 				{
+					"match": "=",
+					"name": "keyword.operator.assignment.qiq"
+				},
+				{
+					"match": "\\b\\w+(?=\\()",
+					"name": "support.function.qiq"
+				},
+				{
+					"match": "=>",
+					"name": "keyword.operator.arrow.qiq"
+				},
+				{
+					"match": "[\\[\\]]",
+					"name": "punctuation.section.array.qiq"
+				},
+				{
 					"match": ":",
 					"name": "punctuation.separator.colon.qiq"
 				},
 				{
-					"match": "\\$[a-zA-Z_][a-zA-Z0-9_]*",
+					"match": "\\$[a-zA-Z_][a-zA-Z0-9_]*(?:->\\w+)*",
 					"name": "variable.other.qiq"
+				},
+				{
+					"include": "#strings"
 				}
 			]
 		}


### PR DESCRIPTION
主な変更点
- =演算子のサポート追加
- 関数名（renderなど）のハイライト追加
- 配列構文（[]）のサポート追加
- アロー演算子（=>）のサポート追加
- プロパティアクセス（->）を含む変数パターンの拡張
- 文字列のサポートを追加（#stringsの再利用）
- これにより、以下のような構文要素がハイライトされるようになります：
